### PR TITLE
Update docs with curl cmdline which follows redirects.

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -67,7 +67,7 @@ The initialization process is quick and painless.
 
     Next install some plugins. Jig has a common set you may like:
 
-        $ curl https://raw.github.com/robmadole/jig-plugins/lists/common.txt > .jigplugins.txt
+        $ curl -L https://raw.github.com/robmadole/jig-plugins/lists/common.txt > .jigplugins.txt
         $ jig install .jigplugins.txt
 
 If there is a pre-existing hook, Jig will not overwrite it.
@@ -148,7 +148,7 @@ For this example we can start with an example Python project list.
 
 .. code-block:: console
 
-    $ curl https://raw.github.com/robmadole/jig-plugins/lists/python.txt > .jigplugins.txt
+    $ curl -L https://raw.github.com/robmadole/jig-plugins/lists/python.txt > .jigplugins.txt
 
 After this is downloaded you can see that each line simply points to a specific
 plugin.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,14 +45,14 @@ Change directories into your Git repository and initialize it to use Jig.
 
     Next install some plugins. Jig has a common set you may like:
 
-        $ curl https://raw.github.com/robmadole/jig-plugins/lists/common.txt > .jigplugins.txt
+        $ curl -L https://raw.github.com/robmadole/jig-plugins/lists/common.txt > .jigplugins.txt
         $ jig install .jigplugins.txt
 
 Create a file that lists the plugins you'd like to install.
 
 .. code-block:: console
 
-    $ curl https://raw.github.com/robmadole/jig-plugins/lists/common.txt > .jigplugins.txt
+    $ curl -L https://raw.github.com/robmadole/jig-plugins/lists/common.txt > .jigplugins.txt
       % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                      Dload  Upload   Total   Spent    Left  Speed
     100    97  100    97    0     0    144      0 --:--:-- --:--:-- --:--:--   425

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -49,7 +49,7 @@ If you haven't, :ref:`install Jig now <install>`.
 
     Next install some plugins. Jig has a common set you may like:
 
-        $ curl https://raw.github.com/robmadole/jig-plugins/lists/common.txt > .jigplugins.txt
+        $ curl -L https://raw.github.com/robmadole/jig-plugins/lists/common.txt > .jigplugins.txt
         $ jig install .jigplugins.txt
 
 If you're curious, you can :ref:`see what this thing has done

--- a/src/jig/commands/hints.py
+++ b/src/jig/commands/hints.py
@@ -12,7 +12,7 @@ AFTER_INIT = _hint(
 
     Next install some plugins. Jig has a common set you may like:
 
-        $ curl https://raw.github.com/robmadole/jig-plugins/lists/common.txt > .jigplugins.txt
+        $ curl -L https://raw.github.com/robmadole/jig-plugins/lists/common.txt > .jigplugins.txt
         $ jig install .jigplugins.txt
     """)
 
@@ -101,7 +101,7 @@ NO_PLUGINS_INSTALLED = _hint(
 
     You can also install a list of plugins from a file:
 
-        $ curl https://raw.github.com/robmadole/jig-plugins/lists/common.txt > .jigplugins.txt
+        $ curl -L https://raw.github.com/robmadole/jig-plugins/lists/common.txt > .jigplugins.txt
         $ jig install .jigplugins.txt
 
     It's a good idea to add .jigplugins.txt to your Git repository after you are done.


### PR DESCRIPTION
To improve security github has moved all user content from the github.com domain to githubuserconent.com domain, see https://developer.github.com/changes/2014-04-25-user-content-security/ for more information.

They offer redirects from the original locations, but curl **won't** follow redirects by default. Annoying `curl` doesn't error even give you an error when it hits a redirect and does nothing! Thus the command 
`curl https://raw.github.com/robmadole/jig-plugins/lists/common.txt > .jigplugins.txt` looks like it succeeds but just ends up creating an empty .jigplugins.txt file. This confused me for a while.
